### PR TITLE
chore: block secrets at commit time with a gitleaks pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Multi-language examples showing how to enrich a [TomTom](https://docs.tomtom.com
 
 ## Local Setup
 
+Run this once after cloning — it wires the tracked git hooks and installs [gitleaks](https://github.com/gitleaks/gitleaks), so no commit containing a secret can be created:
+
+```bash
+./hooks/install.sh
+```
+
+It is idempotent, and needs re-running after a fresh clone or a new git worktree. The `javascript/` package runs it automatically via `npm install`. The [gitleaks CI workflow](.github/workflows/gitleaks.yml) is the backstop for anyone who skips it.
+
 Set environment variables first:
 
 ```bash

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wires git to the tracked hooks/ directory and makes sure gitleaks is present.
+# Plain bash + git + curl: it never invokes the project's own toolchain, so it
+# works the same in a Node, Python, Go, Rust or JVM repo. Idempotent and safe to
+# re-run, so it is fine to call from a bootstrap script or an install hook.
+
+# Hooks do nothing in CI, and a CI install step would run this on every job.
+if [ -n "${CI:-}" ]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Guard 1 — never hijack another hook manager.
+# husky and lefthook claim a repo by setting core.hooksPath themselves. Pointing
+# it at hooks/ would silently stop their lint/test hooks running, with no error.
+# ---------------------------------------------------------------------------
+current="$(git config --get core.hooksPath || true)"
+if [ -n "$current" ]; then
+  case "$current" in
+    /*) current_abs="$current" ;;
+    *)  current_abs="$REPO_ROOT/$current" ;;
+  esac
+  if [ "$current_abs" != "$REPO_ROOT/hooks" ] && [ "${HOOKS_FORCE:-0}" != "1" ]; then
+    echo "[hooks] REFUSING: core.hooksPath is already set to '$current'."
+    echo "[hooks] Another hook manager (husky, lefthook, ...) owns this repo's hooks."
+    echo "[hooks] Repointing it would silently stop those hooks from running."
+    echo "[hooks] Add the gitleaks scan to that setup instead, or force with:"
+    echo "[hooks]   HOOKS_FORCE=1 ./hooks/install.sh"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Guard 2 — core.hooksPath makes git ignore .git/hooks entirely. Anything real
+# in there stops running, silently, so say so rather than let it go unnoticed.
+# ---------------------------------------------------------------------------
+# NOT `git rev-parse --git-path hooks` — that honours core.hooksPath, so once this
+# script has run once it would report our own hooks/ back to us. --git-common-dir
+# gives the real .git (and is worktree-correct, where hooks live in the common dir).
+git_hooks_dir="$(git rev-parse --git-common-dir)/hooks"
+shadowed="$(ls -A "$git_hooks_dir" 2>/dev/null | grep -v '\.sample$' || true)"
+if [ -n "$shadowed" ]; then
+  echo "[hooks] WARNING: these will stop running once core.hooksPath points at hooks/:"
+  echo "$shadowed" | sed "s|^|[hooks]   $git_hooks_dir/|"
+  echo "[hooks] Move anything still needed into $REPO_ROOT/hooks/."
+fi
+
+# Skip-if-missing: not every repo using this script has all five hooks, and under
+# `set -e` a chmod on an absent file would abort before core.hooksPath is set.
+for h in pre-commit pre-merge-commit pre-push post-commit post-checkout; do
+  if [ -f "hooks/$h" ]; then chmod +x "hooks/$h"; fi
+done
+git config core.hooksPath hooks
+echo "[hooks] git now runs $REPO_ROOT/hooks (core.hooksPath)."
+
+# ---------------------------------------------------------------------------
+# gitleaks. The pre-commit hook fails closed without it, so install it here
+# rather than letting the developer discover a blocked commit later.
+# ~/.local/bin is already on the hooks' PATH, so no hook change is needed.
+# ---------------------------------------------------------------------------
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+
+if command -v gitleaks >/dev/null 2>&1; then
+  echo "[hooks] gitleaks $(gitleaks version) present — secret scanning active."
+  exit 0
+fi
+
+echo "[hooks] gitleaks not found — installing it..."
+
+if command -v brew >/dev/null 2>&1 && brew install gitleaks; then
+  echo "[hooks] gitleaks installed via brew."
+  exit 0
+fi
+
+# Fall back to the release tarball, the same source the gitleaks CI Action uses.
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux)  os=linux ;;
+  *) os="" ;;
+esac
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64)  arch=x64 ;;
+  *) arch="" ;;
+esac
+
+# Never fail a bootstrap over this — warn and let the hook's own message guide them.
+if [ -z "$os" ] || [ -z "$arch" ]; then
+  echo "[hooks] WARNING: unsupported platform $(uname -s)/$(uname -m)."
+  echo "[hooks] Install gitleaks manually: https://github.com/gitleaks/gitleaks#installing"
+  exit 0
+fi
+
+ver="$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest 2>/dev/null \
+       | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -1)" || ver=""
+if [ -z "$ver" ]; then
+  echo "[hooks] WARNING: could not reach the GitHub releases API."
+  echo "[hooks] Install gitleaks manually: https://github.com/gitleaks/gitleaks#installing"
+  exit 0
+fi
+
+mkdir -p "$HOME/.local/bin"
+url="https://github.com/gitleaks/gitleaks/releases/download/v${ver}/gitleaks_${ver}_${os}_${arch}.tar.gz"
+if curl -sSfL "$url" | tar -xz -C "$HOME/.local/bin" gitleaks 2>/dev/null; then
+  chmod +x "$HOME/.local/bin/gitleaks"
+  echo "[hooks] gitleaks $ver installed to ~/.local/bin."
+else
+  echo "[hooks] WARNING: download failed ($url)."
+  echo "[hooks] Install gitleaks manually: https://github.com/gitleaks/gitleaks#installing"
+fi
+
+exit 0

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# GUI clients (VS Code, SourceTree, GitHub Desktop, JetBrains) are launched from
+# Finder, not a shell, so they inherit a bare /usr/bin:/bin PATH with no Homebrew.
+# Without this the scan below would "fail closed" on every GUI commit and report
+# gitleaks as missing when it is installed.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:$HOME/.local/bin:$HOME/go/bin:$PATH"
+
+# ---------------------------------------------------------------------------
+# Secret scan — BLOCKING.
+#
+# `gitleaks git --staged` scans only the added lines of the staged diff, so a
+# pre-existing secret elsewhere in a touched file does not re-flag on every
+# commit, and cost stays proportional to the change (~30ms on a normal diff).
+#
+# REPO_ROOT is passed explicitly as the scan target: gitleaks resolves both
+# .gitleaks.toml and .gitleaksignore relative to it, and silently falls back to
+# its built-in defaults when the target is a subdirectory.
+# ---------------------------------------------------------------------------
+if [ "${GITLEAKS_SKIP:-0}" = "1" ]; then
+  echo "[pre-commit] WARNING: GITLEAKS_SKIP=1 — secret scan bypassed for this commit."
+else
+  if ! command -v gitleaks >/dev/null 2>&1; then
+    echo "[pre-commit] BLOCKED: gitleaks is not installed, so this commit cannot be checked for secrets."
+    echo "[pre-commit]   Install: ./hooks/install.sh"
+    echo "[pre-commit]   Or see:  https://github.com/gitleaks/gitleaks#installing"
+    exit 1
+  fi
+
+  # Both files are optional. Passing --config for a file that does not exist is
+  # a fatal error in gitleaks, which the check below would misread as a leak and
+  # block every commit — so only pass the flags when the files are actually there.
+  scan_args=(git --staged --no-banner --redact --verbose)
+  if [ -f "$REPO_ROOT/.gitleaks.toml" ]; then
+    scan_args+=(--config "$REPO_ROOT/.gitleaks.toml")
+  fi
+  if [ -f "$REPO_ROOT/.gitleaksignore" ]; then
+    scan_args+=(--gitleaks-ignore-path "$REPO_ROOT/.gitleaksignore")
+  fi
+  scan_args+=("$REPO_ROOT")
+
+  echo "[pre-commit] Scanning staged changes for secrets..."
+  if ! gitleaks "${scan_args[@]}"; then
+    echo ""
+    echo "[pre-commit] BLOCKED: a secret was found in the staged changes (redacted above)."
+    echo "[pre-commit]   1. Remove it from the code and read it from an env var / secret manager."
+    echo "[pre-commit]   2. Rotate it — treat anything you typed into a file as already leaked."
+    echo "[pre-commit]   3. False positive? Prefer a value-anchored allowlist in .gitleaks.toml."
+    echo "[pre-commit]      It applies to staged, push and CI scans alike; a .gitleaksignore"
+    echo "[pre-commit]      fingerprint only matches the scan mode that printed it."
+    exit 1
+  fi
+  echo "[pre-commit] No secrets found in staged changes."
+fi
+
+exit 0

--- a/hooks/pre-merge-commit
+++ b/hooks/pre-merge-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/hooks/pre-commit"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,6 +4,7 @@
   "description": "### Getting key to access Google Maps APIs. * creating account with MapmyIndia * go to signup/login link https://cloud.google.com/maps-platform/?hl=en * you may need to add Billing Account, in that case make sure you select   Currency as USD.",
   "main": "index.js",
   "scripts": {
+    "prepare": "../hooks/install.sh || true",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
Adds a tracked `hooks/` directory that blocks any commit containing a credential. Plain git + bash, so it is independent of the repo's four language stacks — git runs the hook, not a toolchain.

## What's here

| File | Role |
|------|------|
| `hooks/pre-commit` | scans the **staged diff only** with `gitleaks git --staged`; blocks on a finding |
| `hooks/pre-merge-commit` | same scan for merge commits, which git does **not** run `pre-commit` for |
| `hooks/install.sh` | wires `core.hooksPath` **and** installs gitleaks if missing |

`core.hooksPath` lives in `.git/config` and is not part of the repo, so cloning gets you the hook *files* but not the wiring. Git has no post-clone hook, hence the installer.

## Design notes

- **Fails closed.** A missing gitleaks blocks the commit with an install hint rather than passing it silently.
- **Staged-diff only.** Scans added lines, so a pre-existing secret in a touched file does not re-flag on every commit and cost stays proportional to the change — **~20ms** measured here.
- **Works from GUI clients.** VS Code / JetBrains launch from Finder with a bare `PATH`; the hook prepends the usual Homebrew and `~/.local/bin` paths so the scan does not fail closed on every GUI commit.
- **Won't hijack another hook manager.** If `core.hooksPath` already points elsewhere (husky, lefthook), the installer refuses and explains, rather than silently killing their hooks.
- **Warns about shadowed `.git/hooks`,** which `core.hooksPath` makes git ignore entirely.
- **No-ops under `$CI`** — secret scanning in CI is the workflow's job.

## Auto-run

`javascript/package.json` gets `"prepare": "../hooks/install.sh || true"`, verified to actually fire (unset `core.hooksPath`, ran `npm install`, confirmed it came back). Python, Ruby and PHP have no install lifecycle to hang it off, so the README documents `./hooks/install.sh` as step one after cloning. The `|| true` keeps the installer's deliberate refusals from ever breaking a build.

The existing [gitleaks CI workflow](.github/workflows/gitleaks.yml) remains the backstop for unwired clones.

## Verification

Blocking path — a fake `sk_live_…` key:

```
[pre-commit] Scanning staged changes for secrets...
Finding:     stripe_key = "REDACTED"
RuleID:      stripe-access-token
File:        tmp-hooktest/leak.txt
[pre-commit] BLOCKED: a secret was found in the staged changes (redacted above).
```

Commit rejected, `HEAD` unchanged, test file removed. Clean path passes in ~20ms — the commit on this branch went through the hook itself. gitleaks 8.30.1.

**Emergency bypass:** `GITLEAKS_SKIP=1 git commit ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)