### PR TITLE
ci: fail the gitleaks job when secrets are found

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: "Manual security scan"
 
+permissions:
+  contents: read
+  security-events: write   # required by upload-sarif
+
 jobs:
   gitleaks:
     name: Scan for secrets
@@ -25,73 +29,37 @@ jobs:
           GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
 
+      # The scan records its exit code instead of failing here, so the reports
+      # still reach the SARIF upload and the webhook. The job fails at the end.
       - name: Run gitleaks
+        id: scan
         run: |
-          gitleaks detect --source . --verbose --redact --report-format sarif --report-path gitleaks-report.sarif || true
-          gitleaks detect --source . --verbose --redact --report-format json --report-path gitleaks-report.json || true
+          set +e
+          gitleaks detect --source . --verbose --redact --report-format sarif --report-path gitleaks-report.sarif
+          gitleaks detect --source . --verbose --redact --report-format json --report-path gitleaks-report.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
-      # - name: Upload SARIF report
-      #   if: always()
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   with:
-      #     sarif_file: gitleaks-report.sarif
+      - name: Upload SARIF report
+        if: always()
+        continue-on-error: true   # a reporting failure must not mask the scan result
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks-report.sarif
 
       - name: Send JSON to endpoint
         if: always()
         run: |
+          if [ ! -f gitleaks-report.json ]; then
+            echo "::warning::no gitleaks-report.json to send — the scan produced no report."
+            exit 0
+          fi
           curl -X POST "${{ secrets.SAST_GITLEAK_WEBHOOK_URL }}?branch=${{ github.head_ref || github.ref_name }}&&repo=${{ github.event.repository.name }}" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.SAST_WEBHOOK_TOKEN }}" \
             -d @gitleaks-report.json
 
-# name: Gitleaks Secret Scan
-# on:
-#   pull_request:
-#     branches: [main, master]
-#   schedule:
-#     - cron: '0 3 * * 1'
-#   workflow_dispatch:
-
-# jobs:
-#   gitleaks:
-#     name: Scan for secrets
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-
-#       - name: Install gitleaks
-#         run: |
-#           GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
-#           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
-
-#       - name: Run gitleaks
-#         run: gitleaks detect --source . --verbose --redact --report-format sarif --report-path gitleaks-report.sarif
-
-#       - name: Upload SARIF report
-#         if: always()
-#         uses: github/codeql-action/upload-sarif@v3
-#         with:
-#           sarif_file: gitleaks-report.sarif
-
-# name: Gitleaks Secret Scan
-# on:
-#   pull_request:
-#     branches: [main, master]
-#   schedule:
-#     - cron: '0 3 * * 1'  # Weekly Monday 3am UTC
-#   workflow_dispatch:       # Allow manual trigger
-
-# jobs:
-#   gitleaks:
-#     name: Scan for secrets
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#       - uses: gitleaks/gitleaks-action@v2
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#           GITLEAKS_ENABLE_COMMENTS: false
+      - name: Fail if secrets were found
+        if: steps.scan.outputs.exit_code != '0'
+        run: |
+          echo "::error::gitleaks found secrets — see the scan log above for file, line and commit."
+          exit 1


### PR DESCRIPTION
## Why

A manual run of the gitleaks workflow on `main` ([run 31842758529](https://github.com/mapup/tolltally-toll-for-route-tomtom/actions/runs/31842758529)) reported **`leaks found: 2`** in its log and still finished with a green check.

Two things caused that:
- `|| true` was appended to both `gitleaks detect` invocations, discarding the exit code.
- The `Upload SARIF report` step was commented out, so findings never reached the Security tab either.

The result was a scan that could not fail and whose findings were visible only inside the raw step log or at the SAST webhook. Anyone reading the Actions tab saw success.

## What changed

- The scan step records its exit code as an output rather than swallowing it.
- A final `Fail if secrets were found` gate fails the job when that code is non-zero. It runs **after** the SARIF upload and the webhook POST, so findings are still reported before the job goes red.
- `Upload SARIF report` is restored, with `permissions: security-events: write` and `continue-on-error: true` — a reporting outage must not mask a real leak.
- The webhook step now skips with a warning when no report file exists, instead of failing `curl` on a missing `-d @file`.
- Removed the three superseded workflow definitions that were left commented out at the bottom of the file.

## Scope

Workflow-only. No application code is touched, and **no secrets were removed, because there are none to remove** — `gitleaks detect --no-git` over the working tree reports `no leaks found`, and all four language samples read their keys from the environment (`ruby/main.rb:7`, `python/TomTom.py:8`, `javascript/index.js:5`, `php/php_curl_tomtom.php:4`).

The 2 findings exist only in the history of commit `036048f` (`ruby/main.rb:6` and `:10`), superseded by `05410ff`. Those are being handled separately by a BFG history rewrite plus rotation of the two exposed keys — a PR against `main` cannot reach them.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses; all 6 steps resolve in order.
- Expected behaviour on this PR's own scan run: findings still present in history → the job should now go **red** rather than green. That red is the fix working, and it clears once the history rewrite lands.