### PR TITLE
ci(security): resolve npm ERESOLVE so license inventory is not silently empty

### DIFF
--- a/.github/workflows/license-inventory.yml
+++ b/.github/workflows/license-inventory.yml
@@ -73,7 +73,17 @@ jobs:
             rm -f /tmp/lc-prod.json /tmp/lc-all.json
             (
               cd "$dir" || exit 0
-              npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts 2>/dev/null || true
+              # Several packages here have peer-dependency conflicts, so both
+              # `npm ci` and plain `npm install` abort with ERESOLVE. Without the
+              # --legacy-peer-deps tier no node_modules is produced and
+              # license-checker then reports only the package itself — a green
+              # run carrying an empty inventory, which reads as "no dependencies"
+              # rather than "we failed to look". Warn loudly if all tiers fail.
+              if ! npm ci --ignore-scripts >/dev/null 2>&1 \
+                && ! npm ci --ignore-scripts --legacy-peer-deps >/dev/null 2>&1 \
+                && ! npm install --ignore-scripts --legacy-peer-deps >/dev/null 2>&1; then
+                echo "::warning::npm install failed in $dir — its dependencies are NOT in the license inventory"
+              fi
               license-checker --json --out /tmp/lc-prod.json --production 2>/dev/null || true
               license-checker --json --out /tmp/lc-all.json 2>/dev/null || true
             ) || true


### PR DESCRIPTION
Follow-up: the nested-manifest walk works, but the inventory it produced was mostly empty — and it was passing green while empty.

## The symptom
`license-inventory` reported **108 production npm packages** for this repo. The Trivy SBOM for the *same* dependency trees lists **1,687**. Eight of the nine nested packages contributed exactly one entry — themselves.

## The cause
Those packages have peer-dependency conflicts, so **both** `npm ci` and plain `npm install` abort with ERESOLVE. `stderr` was discarded, so nothing surfaced: no `node_modules` was created, license-checker fell back to reporting just the root package, and the step exited 0.

That is the dangerous failure mode — **"no dependencies" and "we failed to look" render identically** on the dashboard. An outright red run would have been safer.

Reproduced on `polygons_monitor`:
```
npm error Could not resolve dependency:
npm error peer serverless@"^3.2.0" from serverless-offline@13.9.0
npm error Conflicting peer dependency: serverless@3.40.0
```

## The fix
Adds a `--legacy-peer-deps` tier to the install chain, and emits a `::warning::` annotation when **every** tier fails, so an empty inventory can never pass silently again.

Verified on the same package:

| | packages installed | license-checker entries |
|---|---|---|
| `npm ci` (current) | fails ERESOLVE | **1** |
| `npm ci --legacy-peer-deps` | 197 | **297** |

`--legacy-peer-deps` only affects how npm resolves the tree for this throwaway inventory checkout. It does not touch any lockfile, and nothing is built or deployed from it — `--ignore-scripts` is still set.

---
YAML validated; rewritten shell block passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)