### PR TITLE
ci(security): harden scanner installers against upstream flakiness

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,8 +26,22 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
+          # The old one-liner (grep + greedy sed) depended on the GitHub API
+          # returning pretty-printed JSON. When it returns compact JSON the
+          # greedy .* swallows the rest of the payload, GITLEAKS_VERSION becomes
+          # a JSON fragment and the download URL is malformed — curl (3) "bad
+          # range specification", then tar fails on the truncated stream.
+          # Parse with jq, sanity-check the result, and pin a fallback.
+          GITLEAKS_VERSION=$(curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors --connect-timeout 15 -H 'Accept: application/vnd.github+json' \
+            https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | jq -r '.tag_name // empty' | sed 's/^v//')
+          case "$GITLEAKS_VERSION" in
+            ''|*[!0-9.]*)
+              echo "::warning::could not resolve latest gitleaks version — using pinned fallback."
+              GITLEAKS_VERSION=8.30.1 ;;
+          esac
+          echo "Installing gitleaks v${GITLEAKS_VERSION}"
+          curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors --connect-timeout 15 "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
 
       # The scan records its exit code instead of failing here, so the reports
       # still reach the SARIF upload and the webhook. The job fails at the end.

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           set -euo pipefail
           tarball="trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz"
-          curl -sSfL -o "$tarball" \
+          curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors --connect-timeout 15 -o "$tarball" \
             "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/${tarball}"
           echo "${TRUFFLEHOG_SHA256}  ${tarball}" | sha256sum -c -
           tar -xzf "$tarball" -C /usr/local/bin trufflehog


### PR DESCRIPTION
Two independent installer failures observed today, both of which turned a **clean scan** red and surfaced as `Failing` on the coverage tracker.

## 1. Gitleaks version parse — intermittent, environment-dependent
```sh
GITLEAKS_VERSION=$(curl -s .../releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
```
This only works when the GitHub API returns **pretty-printed** JSON. When it returns **compact** JSON, `grep` matches the entire payload and the greedy `.*` swallows everything after the last `"v` — so `GITLEAKS_VERSION` becomes a JSON fragment:

```
curl: (3) bad range specification in URL position 236:
https://github.com/.../download/v8.30.1","draft":false,"immutable":false,...
gzip: stdin: unexpected end of file
tar: Error is not recoverable: exiting now
```

That is exactly why it looks random: the same command returns `8.30.1` in one environment and garbage in another. I confirmed both behaviours.

Now parsed with `jq`, sanity-checked against a numeric pattern, and backed by a pinned fallback so a bad API response degrades instead of failing.

## 2. Transient upstream 504s — this is the TruffleHog failure
Both scanners fetch release artifacts with **no retry budget**, so one gateway blip fails the whole job:

```
trufflesecurity/trufflehog err http_download_curl received HTTP status 504
curl: (22) The requested URL returned error: 504
```

Both TruffleHog failures happened within the same minute across two different repos and two different hosts — a GitHub-side blip, not a defect here. Historically rare (1 failure in 8 runs, 1 in 13), but it costs a red scan each time.

Adds `--retry 5 --retry-all-errors` to the fetches. Where the vendor install script does its **own** download, the 504 occurs inside it where curl flags cannot reach, so the script invocation itself is retried with backoff.

## What is deliberately unchanged
All existing hardening stays exactly as-is — pinned versions, published SHA256 checksums, fetch-to-disk-then-run instead of piping to a shell. `tollguru-mobile-app`’s gitleaks is already pinned deliberately, so it keeps its pin and only gains retries. This PR makes network fetches resilient; it does not relax any supply-chain control.

---
YAML validated; every run block passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)