### PR TITLE
ci(security): don't upload SBOM to Dependency-Track from pull requests

### DIFF
--- a/.github/workflows/universal-dependency-track.yml
+++ b/.github/workflows/universal-dependency-track.yml
@@ -170,7 +170,26 @@ jobs:
               componentsWithLicenses: ([.components[] | select(.licenses)] | length)
           }'
 
+      - name: Check Dependency-Track credentials
+        id: dt_check
+        env:
+          DEPENDENCYTRACK_API_KEY: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+        run: |
+          if [ -n "$DEPENDENCYTRACK_API_KEY" ]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "DEPENDENCYTRACK_API_KEY not set — Dependency-Track upload will be skipped."
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload BOM to Dependency-Track
+        # Two reasons this must not run on pull requests:
+        #  1. projectversion below is hardcoded to the default branch, so a PR
+        #     upload overwrites the default-branch SBOM in Dependency-Track
+        #     with the contents of an unmerged branch.
+        #  2. dependabot-triggered runs get no secrets, so the API key is empty
+        #     and the upload 401s — failing a job whose scan actually succeeded.
+        if: github.event_name != 'pull_request' && steps.dt_check.outputs.upload == 'true'
         uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5 # v3.1.0
         with:
           serverhostname: '44.194.0.211'


### PR DESCRIPTION
`Trivy` shows `Failing` on the tracker, but **Trivy is not failing**. On run [32480992806](https://github.com/mapup/tolltally-toll-for-route-tomtom/actions/runs/32480992806) the scan completed cleanly:

```
success   Generate SBOM with Trivy
success   Clean and validate SBOM
failure   Upload BOM to Dependency-Track
```

```
##[warning]Can't add secret mask for empty string in ##[add-mask] command.
##[error]Failed response status code:401
```

The empty-string mask warning is the tell: `DEPENDENCYTRACK_API_KEY` is blank. GitHub **withholds secrets from dependabot-triggered runs**, so the upload authenticates with nothing and gets a 401 — reddening a job whose scan succeeded. Same root cause as the gitleaks webhook failure fixed earlier, in a different workflow.

## The second problem, which is worse
`projectversion` on this step is hardcoded to the default branch. Every pull-request run was therefore uploading **its own branch's SBOM over the default-branch project in Dependency-Track**. Dependency-Track has been showing whichever PR ran most recently, not what is actually on the default branch.

That silently corrupts the dashboard rather than failing loudly, so it would not have shown up as a red run at all.

## Fix
Skip the upload on pull requests entirely, and verify the API key is present before uploading:

```yaml
if: github.event_name != pull_request && steps.dt_check.outputs.upload == 'true'
```

PR runs still generate and validate the SBOM and still archive it as an artifact — only the publish step is skipped. Default-branch, scheduled and manual runs are unchanged.

This is the same guard `navguru-mobile-app` and `tollguru-mobile-app` already use, and it matches the `sbom_check` idiom already present in `syft-sbom.yml` and `scancode.yml` in this repo. Those two were already correct — this brings the Trivy workflow in line.

---
YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)